### PR TITLE
Don't assign reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,6 @@ updates:
     day: friday
     time: "04:00"
   open-pull-requests-limit: 10
-  reviewers:
-  - koppen
   versioning-strategy: lockfile-only
   ignore:
   - dependency-name: rspec-rails
@@ -34,8 +32,6 @@ updates:
     day: friday
     time: "04:00"
   open-pull-requests-limit: 10
-  reviewers:
-  - koppen
   versioning-strategy: increase-if-necessary
   ignore:
   - dependency-name: mini-css-extract-plugin


### PR DESCRIPTION
My list of pull requests awaiting code review is getting too long. I'd usually prefer to focus on reviews from people as they might be blocked in development.

Bot-generated pull requests are usually not as time-sensitive, so we should be able to review them at our own pace - usually as part of a maintenance agreement day.